### PR TITLE
feat(urdf): add merged lidar link

### DIFF
--- a/config/ros2_controller/real_controllers.yaml
+++ b/config/ros2_controller/real_controllers.yaml
@@ -12,14 +12,14 @@ controller_manager:
     omni_wheel_drive_controller:
       type: omni_wheel_drive_controller/OmniWheelDriveController
 
-    head_servo_controller:
-      type: position_controllers/JointGroupPositionController
+    # head_servo_controller:
+    #   type: position_controllers/JointGroupPositionController
 
-    left_arm_controller:
-      type: joint_trajectory_controller/JointTrajectoryController
+    # left_arm_controller:
+    #   type: joint_trajectory_controller/JointTrajectoryController
     
-    left_hand_controller:
-      type: position_controllers/GripperActionController  
+    # left_hand_controller:
+    #   type: position_controllers/GripperActionController  
 
 forward_velocity_controller:
   ros__parameters:
@@ -45,7 +45,7 @@ omni_wheel_drive_controller:
         "fr_wheel_joint",
       ]
 
-    robot_radius: 0.2022325394193526
+    robot_radius: 0.18518136649782
     wheel_radius: 0.076
 
     odom_frame_id: odom
@@ -60,47 +60,47 @@ omni_wheel_drive_controller:
     cmd_vel_timeout: 0.5
     publish_limited_velocity: true
 
-head_servo_controller:
-  ros__parameters:
-    joints:
-      - head_servo_joint
-    command_interfaces:
-      - position
-    state_interfaces:
-      - position
-    open_loop: true
-    allow_nonzero_velocity_at_steady_state: true
+# head_servo_controller:
+#   ros__parameters:
+#     joints:
+#       - head_servo_joint
+#     command_interfaces:
+#       - position
+#     state_interfaces:
+#       - position
+#     open_loop: true
+#     allow_nonzero_velocity_at_steady_state: true
 
-left_arm_controller:
-  ros__parameters:
-    joints:
-      - left_joint1
-      - left_joint2
-      - left_joint3
-      - left_joint4
-      - left_joint5
-      - left_joint6
-      - left_joint7
-    command_interfaces:
-      - position
-    state_interfaces:
-      - position
-      - velocity
-    allow_nonzero_velocity_at_trajectory_end: true
+# left_arm_controller:
+#   ros__parameters:
+#     joints:
+#       - left_joint1
+#       - left_joint2
+#       - left_joint3
+#       - left_joint4
+#       - left_joint5
+#       - left_joint6
+#       - left_joint7
+#     command_interfaces:
+#       - position
+#     state_interfaces:
+#       - position
+#       - velocity
+#     allow_nonzero_velocity_at_trajectory_end: true
 
-left_hand_controller:
-  ros__parameters:
-    joint: left_gripper_worm_gear_joint
+# left_hand_controller:
+#   ros__parameters:
+#     joint: left_gripper_worm_gear_joint
     
-    # Control parameters
-    goal_tolerance: 0.01
-    max_effort: 100.0
-    max_velocity: 0.1
+#     # Control parameters
+#     goal_tolerance: 0.01
+#     max_effort: 100.0
+#     max_velocity: 0.1
     
-    # Stalling detection (useful for grasping)
-    allow_stalling: true
-    stall_velocity_threshold: 0.001
-    stall_timeout: 1.0
+#     # Stalling detection (useful for grasping)
+#     allow_stalling: true
+#     stall_velocity_threshold: 0.001
+#     stall_timeout: 1.0
     
-    # Action monitoring
-    action_monitor_rate: 20.0
+#     # Action monitoring
+#     action_monitor_rate: 20.0

--- a/config/ros2_controller/real_controllers.yaml
+++ b/config/ros2_controller/real_controllers.yaml
@@ -12,8 +12,8 @@ controller_manager:
     omni_wheel_drive_controller:
       type: omni_wheel_drive_controller/OmniWheelDriveController
 
-    # head_servo_controller:
-    #   type: position_controllers/JointGroupPositionController
+    head_servo_controller:
+      type: position_controllers/JointGroupPositionController
 
     # left_arm_controller:
     #   type: joint_trajectory_controller/JointTrajectoryController
@@ -60,16 +60,17 @@ omni_wheel_drive_controller:
     cmd_vel_timeout: 0.5
     publish_limited_velocity: true
 
-# head_servo_controller:
-#   ros__parameters:
-#     joints:
-#       - head_servo_joint
-#     command_interfaces:
-#       - position
-#     state_interfaces:
-#       - position
-#     open_loop: true
-#     allow_nonzero_velocity_at_steady_state: true
+head_servo_controller:
+  ros__parameters:
+    joints:
+      - head_servo_joint
+    command_interfaces:
+      - position
+    state_interfaces:
+      - position
+    open_loop: true
+    allow_nonzero_velocity_at_steady_state: true
+
 
 # left_arm_controller:
 #   ros__parameters:

--- a/robots/gz_walkie.urdf.xacro
+++ b/robots/gz_walkie.urdf.xacro
@@ -66,16 +66,16 @@
     <xacro:lidar_gazebo_v0 prefix="front" min_rad="-2.09333333" max_rad=" 2.09333333" min_range="0.18" max_range="10" yaw_offset="0"/>
     <xacro:lidar_gazebo_v0 prefix="back" min_rad="-2.09333333" max_rad=" 2.09333333" min_range="0.18" max_range="10" yaw_offset="0"/>
   </xacro:unless>
+  <link name="merged_lidar_link"/>
+  <joint name="merged_lidar_joint" type="fixed">
+    <parent link="base_link"/>
+    <child link="merged_lidar_link"/>
+    <origin xyz="0 0 0.28232" rpy="0 0 0"/>
+  </joint>
   <!-- depth cam sensor -->
   <xacro:sensor_d415 name="bottom" parent="base_link" flag_color="1" flag_ir="0" flag_depth="1" updaterate="2">
     <origin xyz="0 -0.245763 0.17000" rpy="0 0.34906585 -${M_PI/2}"/>
   </xacro:sensor_d415>
-  <link name="bottombase"/>
-  <joint name="bottombase_joint" type="fixed">
-    <parent link="base_link"/>
-    <child link="bottombase"/>
-    <origin xyz="0 -0.245763 0.17000" rpy="0 0 -${M_PI/2}"/>
-  </joint>
   <!-- head servo -->
   <xacro:servo_v0 prefix="head" parent="lift_link">
     <origin xyz="-0.03403 -0.2650 0.21525" rpy="0 0 0" />

--- a/robots/gz_walkie.urdf.xacro
+++ b/robots/gz_walkie.urdf.xacro
@@ -77,8 +77,8 @@
     <origin xyz="0 -0.245763 0.17000" rpy="0 0.34906585 -${M_PI/2}"/>
   </xacro:sensor_d415>
   <!-- head servo -->
-  <xacro:servo_v0 prefix="head" parent="lift_link">
-    <origin xyz="-0.03403 -0.2650 0.21525" rpy="0 0 0" />
+  <xacro:servo_v0 prefix="head" parent="base_link">
+    <origin xyz="-0.03403 -0.2650 0.61525" rpy="0 0 0" />
     <!-- <origin xyz="-0.098 -0.1195 0.848" rpy="0 0 0"/> -->
   </xacro:servo_v0>
 

--- a/urdf/walkie/ros2_control.xacro
+++ b/urdf/walkie/ros2_control.xacro
@@ -270,16 +270,6 @@
         </hardware>
         <xacro:cubemars_wheel_joint
                     name="fl_wheel_joint"
-                    can_id="3"
-                    pole_pairs="14"
-                    gear_ratio="10"
-                    kt="0.123"
-                    enc_off="0.0"
-                    trq_limit="30"
-                    read_only="0"
-                />
-        <xacro:cubemars_wheel_joint
-                    name="fr_wheel_joint"
                     can_id="1"
                     pole_pairs="14"
                     gear_ratio="10"
@@ -289,8 +279,18 @@
                     read_only="0"
                 />
         <xacro:cubemars_wheel_joint
+                    name="fr_wheel_joint"
+                    can_id="3"
+                    pole_pairs="14"
+                    gear_ratio="10"
+                    kt="0.123"
+                    enc_off="0.0"
+                    trq_limit="30"
+                    read_only="0"
+                />
+        <xacro:cubemars_wheel_joint
                     name="br_wheel_joint"
-                    can_id="4"
+                    can_id="2"
                     pole_pairs="14"
                     gear_ratio="10"
                     kt="0.123"
@@ -300,7 +300,7 @@
                 />
         <xacro:cubemars_wheel_joint
                     name="bl_wheel_joint"
-                    can_id="2"
+                    can_id="4"
                     pole_pairs="14"
                     gear_ratio="10"
                     kt="0.123"


### PR DESCRIPTION
## Summary
- Add `merged_lidar_link` as a fixed virtual link on `base_link` (z=0.28232 m) to serve as a unified frame for front/back lidar topic merging
- Remove old `bottombase` link which is superseded by the new merged lidar link
- Correct CAN IDs for wheel joints: swap `fl_wheel_joint` (3→1) / `fr_wheel_joint` (1→3) and `br_wheel_joint` (4→2) / `bl_wheel_joint` (2→4)
- Update `robot_radius` to `0.18518` in real_controllers.yaml

## Controllers temporarily disabled
`head_servo_controller`, `left_arm_controller`, and `left_hand_controller` are commented out in `real_controllers.yaml`. These are **work in progress** — hardware integration for the head servo and arm is still being developed and will be re-enabled (or moved to a dedicated branch) in a future PR.

## Test plan
- [x] Verify `merged_lidar_link` appears correctly in RViz/robot_state_publisher TF tree
- [x] Confirm lidar topics can be merged/remapped under `merged_lidar_link` frame
- [x] Test wheel direction correctness after CAN ID swap
- [x] Validate omni wheel drive with updated `robot_radius`